### PR TITLE
Read value property > value attribute

### DIFF
--- a/src/field-assist.ts
+++ b/src/field-assist.ts
@@ -24,7 +24,7 @@ function normalizeValue(e: HTMLInputElement, context: any) {
                 return {skip: true}
             break
         default:
-            value = e.nodeValue || e.getAttribute('value') || e['value'] || e.textContent
+            value = e.nodeValue || e['value'] || e.textContent
     }
 
     const customValidator = e.getAttribute('validator')


### PR DESCRIPTION
The element property value will contain the user input _or_ the default value, whereas the attribute value will only ever contain the default value (if set), unless some other JS changes it.